### PR TITLE
[FEATURE] Add Base to support EVMs

### DIFF
--- a/apps/docs/src/apps/evm.md
+++ b/apps/docs/src/apps/evm.md
@@ -11,6 +11,7 @@ Supported coins from the evm family are:
 7. Ethereum Classic
 8. Arbitrum
 9. Optimism
+10. Base
 
 ## 1. Generate Address
 

--- a/apps/docs/src/introduction.md
+++ b/apps/docs/src/introduction.md
@@ -21,6 +21,6 @@ technologies:
 | Coin Family | Coins                                                                                                                          |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Bitcoin     | - Bitcoin (Legacy & Native Segwit)<br>- Litecoin<br>- Dogecoin<br>- Dashcoin                                                   |
-| EVM         | - Ethereum<br>- Polygon<br>- Binance<br>- Fantom<br>- Avalanche<br>- Harmony<br>- Ethereum Classic<br>- Arbitrum<br>- Optimism |
+| EVM         | - Ethereum<br>- Polygon<br>- Binance<br>- Fantom<br>- Avalanche<br>- Harmony<br>- Ethereum Classic<br>- Arbitrum<br>- Optimism<br>- Base |
 | Solana      | - Solana                                                                                                                       |
 | Near        | - Near                                                                                                                         |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,6 @@ technologies:
 | Coin Family | Coins                                                                                       | Package                                                  |
 | ----------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | Bitcoin     | - Bitcoin (Legacy & Native Segwit)<br>- Litecoin<br>- Dogecoin<br>- Dashcoin                | [@cypherock/sdk-app-btc](../cypherock-sdk-app-btc)       |
-| EVM         | - Ethereum<br>- Polygon<br>- Binance<br>- Fantom<br>- Avalanche<br>- Arbitrum<br>- Optimism | [@cypherock/sdk-app-evm](../cypherock-sdk-app-evm)       |
+| EVM         | - Ethereum<br>- Polygon<br>- Binance<br>- Fantom<br>- Avalanche<br>- Arbitrum<br>- Optimism<br>- Base | [@cypherock/sdk-app-evm](../cypherock-sdk-app-evm)       |
 | Solana      | - Solana                                                                                    | [@cypherock/sdk-app-solana](../cypherock-sdk-app-solana) |
 | Near        | - Near                                                                                      | [@cypherock/sdk-app-near](../cypherock-sdk-app-near)     |

--- a/packages/app-evm/docs/index.md
+++ b/packages/app-evm/docs/index.md
@@ -14,6 +14,7 @@ EVM coin family.
 - Avalanche: (ChainId: `43114`)
 - Arbitrum: (ChainId: `42161`)
 - Optimism: (ChainId: `10`)
+- Base: (ChainId: `8453`)
 
 ## 2. Usage
 

--- a/packages/app-evm/src/constants/appId.ts
+++ b/packages/app-evm/src/constants/appId.ts
@@ -15,6 +15,8 @@ export const chainToAppIdMap: Record<number, number | undefined> = {
   10: 0x0e,
   // Arbitrum
   42161: 0x11,
+  // Base
+  8453: 0x2105,
 };
 
 export const APP_VERSION = {


### PR DESCRIPTION
Currently the Cypherrock does not support the Base Chain. As this chain is gaining popularity, I decided it would be good to add it to the list of support EVM compatible chains